### PR TITLE
Use Stargaze Response in Whitelist-Updatable

### DIFF
--- a/contracts/name-minter/src/integration_tests.rs
+++ b/contracts/name-minter/src/integration_tests.rs
@@ -42,7 +42,7 @@ pub fn contract_collection() -> Box<dyn Contract<StargazeMsgWrapper>> {
 }
 
 pub fn contract_whitelist() -> Box<dyn Contract<StargazeMsgWrapper>> {
-    let contract = ContractWrapper::new_with_empty(
+    let contract = ContractWrapper::new(
         whitelist_updatable::contract::execute,
         whitelist_updatable::contract::instantiate,
         whitelist_updatable::contract::query,

--- a/contracts/whitelist-updatable/src/contract.rs
+++ b/contracts/whitelist-updatable/src/contract.rs
@@ -2,7 +2,7 @@ use crate::state::{Config, CONFIG, TOTAL_ADDRESS_COUNT, WHITELIST};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Addr, Binary, Deps, DepsMut, Env, Event, MessageInfo, Order, Response, StdResult,
+    to_binary, Addr, Binary, Deps, DepsMut, Env, Event, MessageInfo, Order, StdResult,
 };
 use cw2::set_contract_version;
 
@@ -10,6 +10,7 @@ use crate::error::ContractError;
 use crate::msg::{ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 use cw_utils::nonpayable;
 use sg_name_minter::{ParamsResponse, SgNameMinterQueryMsg};
+use sg_std::Response;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:whitelist-updatable";

--- a/contracts/whitelist-updatable/src/integration_tests.rs
+++ b/contracts/whitelist-updatable/src/integration_tests.rs
@@ -19,7 +19,7 @@ mod tests {
     }
 
     pub fn wl_contract() -> Box<dyn Contract<StargazeMsgWrapper>> {
-        let contract = ContractWrapper::new_with_empty(
+        let contract = ContractWrapper::new(
             crate::contract::execute,
             crate::contract::instantiate,
             crate::contract::query,


### PR DESCRIPTION
We can use the StargazeResponse in this repo if we change the imports. Changing to be more consistent with other contracts/unit tests.  