### PR TITLE
Updating --lib flag in cargo wasm alias

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,4 +1,4 @@
 [alias]
-wasm = "build --release --target wasm32-unknown-unknown"
+wasm = "build --release --target wasm32-unknown-unknown --lib"
 wasm-debug = "build --target wasm32-unknown-unknown"
 unit-test = "test --lib"


### PR DESCRIPTION
Need to add --lib flag to Cargo wasm alias in order to avoid weird errors on local build