### PR TITLE
Prevent over-funding of a renewal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "name-marketplace"
-version = "2.1.0"
+version = "2.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "name-minter"
-version = "2.1.0"
+version = "2.1.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "sg-name"
-version = "2.1.0"
+version = "2.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "sg-name-common"
-version = "2.1.0"
+version = "2.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "sg-name-market"
-version = "2.1.0"
+version = "2.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "sg-name-minter"
-version = "2.1.0"
+version = "2.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "sg-whitelist-basic"
-version = "2.1.0"
+version = "2.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "sg721-name"
-version = "2.1.0"
+version = "2.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1331,7 +1331,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "whitelist-updatable"
-version = "2.1.0"
+version = "2.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "whitelist-updatable-flatrate"
-version = "2.1.0"
+version = "2.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["packages/*", "contracts/*"]
 resolver = "2"
 
 [workspace.package]
-version    = "2.1.0"
+version    = "2.1.2"
 edition    = "2021"
 homepage   = "https://stargaze.zone"
 repository = "https://github.com/public-awesome/names"

--- a/contracts/marketplace/schema/name-marketplace.json
+++ b/contracts/marketplace/schema/name-marketplace.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "name-marketplace",
-  "contract_version": "2.1.0",
+  "contract_version": "2.1.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/marketplace/src/error.rs
+++ b/contracts/marketplace/src/error.rs
@@ -54,7 +54,7 @@ pub enum ContractError {
     InsufficientRenewalFunds { expected: Coin, actual: Coin },
 
     #[error("ExcededRenewalFund: expected {expected}, actual {actual}")]
-    ExcededRenewalFund { expected: Coin, actual: Coin },
+    ExceededRenewalFund { expected: Coin, actual: Coin },
 
     #[error("InvalidRenewalPrice")]
     InvalidRenewalPrice {},

--- a/contracts/marketplace/src/error.rs
+++ b/contracts/marketplace/src/error.rs
@@ -53,6 +53,12 @@ pub enum ContractError {
     #[error("InsufficientRenewalFunds: expected {expected}, actual {actual}")]
     InsufficientRenewalFunds { expected: Coin, actual: Coin },
 
+    #[error("ExcededRenewalFund: expected {expected}, actual {actual}")]
+    ExcededRenewalFund { expected: Coin, actual: Coin },
+
+    #[error("InvalidRenewalPrice")]
+    InvalidRenewalPrice {},
+
     #[error("Cannot remove ask with existing bids")]
     ExistingBids {},
 

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -472,7 +472,7 @@ pub fn execute_fund_renewal(
     if let Some(renewal_price_coin) = renewal_price.0.as_ref() {
         ensure!(
             ask.renewal_fund + payment <= renewal_price_coin.amount,
-            ContractError::ExcededRenewalFund {
+            ContractError::ExceededRenewalFund {
                 expected: coin(renewal_price_coin.amount.u128(), NATIVE_DENOM),
                 actual: coin(ask.renewal_fund.u128() + payment.u128(), NATIVE_DENOM),
             }

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -467,9 +467,10 @@ pub fn execute_fund_renewal(
     let renewal_price =
         query_ask_renew_price(deps.as_ref(), ask.renewal_time, (&token_id).to_string())?;
 
-    // check if renewal_fund + payment > renewal_price
+    // make sure that we do not over fund the renewal
+    // based on the price we got back
     ensure!(
-        ask.renewal_fund + payment > renewal_price.0.as_ref().unwrap().amount,
+        ask.renewal_fund + payment <= renewal_price.0.as_ref().unwrap().amount,
         ContractError::InsufficientRenewalFunds {
             expected: coin(renewal_price.0.unwrap().amount.u128(), NATIVE_DENOM),
             actual: coin(ask.renewal_fund.u128() + payment.u128(), NATIVE_DENOM),

--- a/contracts/name-minter/schema/name-minter.json
+++ b/contracts/name-minter/schema/name-minter.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "name-minter",
-  "contract_version": "2.1.0",
+  "contract_version": "2.1.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/name-minter/src/integration_tests.rs
+++ b/contracts/name-minter/src/integration_tests.rs
@@ -1507,7 +1507,8 @@ mod query {
         assert!(response.is_ok());
         let renewal_price = response.unwrap().0.unwrap();
 
-        let fund_amount = coins(renewal_price.amount.u128() * 100_u128, NATIVE_DENOM);
+        // send set the fund_amount to the exact price
+        let fund_amount = coins(renewal_price.amount.u128(), NATIVE_DENOM);
         app.sudo(CwSudoMsg::Bank({
             BankSudo::Mint {
                 to_address: USER.to_string(),
@@ -1522,7 +1523,7 @@ mod query {
             &MarketplaceExecuteMsg::FundRenewal {
                 token_id: NAME.to_string(),
             },
-            &[coin(renewal_price.amount.u128() - 1u128, NATIVE_DENOM)],
+            &[coin(renewal_price.amount.u128(), NATIVE_DENOM)],
         );
         assert!(result.is_ok());
 

--- a/contracts/sg721-name/schema/sg721-name.json
+++ b/contracts/sg721-name/schema/sg721-name.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "sg721-name",
-  "contract_version": "2.1.0",
+  "contract_version": "2.1.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
This PR prevents potential abuse of the renewal funding mechanism by rejecting the over-funding of a renewal. The hypothetical rug would be something like:

```
1. Douchebag creates a collection and mints a name for it called “RugBotz”
2. Douchebag pump their discord community to fund the name renewal, perhaps offering an airdrop or something for community members who “pitch in”
3. (Optional) Douchebag spins up a simple web app on their “RugBotz” so community members can fund the renewal without going to stargaze.zone, making it easier to run their rug such as inflating the renewal cost or something
4. Douchebag checks the fund balance and decides its rug time then cancels the renewal, receiving all the funds their community “pitched in”
```

with these changes the over-funding would be blocked. the renewal mechanism still allows non-name owners to fund a renewal and it does not track the wallets and how much they funded. as such if a renewal is canceled and refunded those funds will go to the name owner. since the over-funding is blocked it reduces the potential loss of funds for the non-owners. it may be prudent to address this with a future change which could:

1. prevent non-owners from funding a renewal (side-steps the issue altogether, however makes it impossible to crowd fund a renewal for a speedy name)

or 

2. update the funding mechanism to track wallet->funded_amount (still allows for crowd funded renewals but ensures upon a canceled renewal everyone gets their $ back)


changes

- when funding check current_fund + payment <= renewal_price
- adds test to cover rejecting over-funding (adds  `ExceededRenewalFund ` `ContractError` type)
- adds test to ensure partial funding still works