### PR TITLE
allow no-cost manual renewal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "name-marketplace"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "name-minter"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "sg-name"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "sg-name-common"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "sg-name-market"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "sg-name-minter"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "sg-whitelist-basic"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "sg721-name"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1331,7 +1331,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "whitelist-updatable"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "whitelist-updatable-flatrate"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["packages/*", "contracts/*"]
 resolver = "2"
 
 [workspace.package]
-version    = "2.2.0"
+version    = "2.2.1"
 edition    = "2021"
 homepage   = "https://stargaze.zone"
 repository = "https://github.com/public-awesome/names"

--- a/contract_code_ids.txt
+++ b/contract_code_ids.txt
@@ -1,0 +1,31 @@
+name_marketplace.wasm: 
+code_id:4289, 4320, 4399
+contract_address:
+stars1vs72epl4v9cd53wyeh57lk9595txf2w7k4764qhr5fxyt50xcksq8kyc9w 
+stars1xg2dhc22makmn93e72agwa86clshha2jwtm0l2kgduqfl5qaplmqngrln4
+stars1m4nkl9a7grq0es95aggz75pdt033nk4aghvkr74ywx9f4mm69qhsrsqjkw
+
+name_minter.wasm: 
+code_id: 4290
+contract_address:stars15689t72jjnpd0y78vnrcw0ssz0y7hx5v0etq6gysygw66kcz6u0q9duh0g 
+stars1evwy29sv74rtzl7gpp2slgml3732dp00eagq0jmsg0h7eutglluq49u0h7
+stars17m20l2xfrlceygdmjfjqf0xwua7jnqrvn4c0jdjfskdavkuykhrq8zdvfn
+
+sg721_name.wasm: 
+code_id: 4291 
+{
+  "image": "ipfs://example.com",
+  "collection_name": "Name Tokens",
+  "sg721_names_addr": "stars1k4kxtwjp94c4uz3fdfpr965zxferz4d8e7lw232umnns48hzgkvq2fm9j4"
+  stars1wgd2sqfk6tya6lhx37fcstwehjvlw22rn69d9fvlwypea6vg87gsl9pal6
+}
+
+
+whitelist_updatable.wasm:
+code_id:4177
+contract_address:
+
+whitelist_updatable_flatrate.wasm:
+tx:
+code_id: 4178
+contract_address:

--- a/contracts/marketplace/schema/name-marketplace.json
+++ b/contracts/marketplace/schema/name-marketplace.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "name-marketplace",
-  "contract_version": "2.2.0",
+  "contract_version": "2.2.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -541,7 +541,7 @@ pub fn execute_renew(
         .querier
         .query_wasm_smart::<NameMinterParams>(name_minter, &SgNameMinterQueryMsg::Params {})?;
 
-    let (renewal_price, _valid_bid) = get_renewal_price_and_bid(
+    let (renewal_price, valid_bid) = get_renewal_price_and_bid(
         deps.as_ref(),
         &env.block.time,
         &sudo_params,
@@ -549,7 +549,7 @@ pub fn execute_renew(
         name_minter_params.base_price.u128(),
     )?;
     let mut final_price = renewal_price;
-    if let Some(_valid_bid) = _valid_bid {
+    if let Some(_bid) = valid_bid {
         let payment = may_pay(&info, NATIVE_DENOM)?;
 
         ask.renewal_fund += payment;

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -548,22 +548,26 @@ pub fn execute_renew(
         &ask.token_id,
         name_minter_params.base_price.u128(),
     )?;
+    let mut final_price = renewal_price;
+    if let Some(_valid_bid) = _valid_bid {
+        let payment = may_pay(&info, NATIVE_DENOM)?;
 
-    let payment = may_pay(&info, NATIVE_DENOM)?;
-
-    ask.renewal_fund += payment;
-
-    ensure!(
-        ask.renewal_fund >= renewal_price,
-        ContractError::InsufficientRenewalFunds {
-            expected: coin(renewal_price.u128(), NATIVE_DENOM),
-            actual: coin(ask.renewal_fund.u128(), NATIVE_DENOM),
-        }
-    );
+        ask.renewal_fund += payment;
+    
+        ensure!(
+            ask.renewal_fund >= renewal_price,
+            ContractError::InsufficientRenewalFunds {
+                expected: coin(renewal_price.u128(), NATIVE_DENOM),
+                actual: coin(ask.renewal_fund.u128(), NATIVE_DENOM),
+            }
+        );
+    } else {
+        final_price = Uint128::zero();
+    }
 
     let mut response = Response::new();
 
-    response = renew_name(deps, &env, &sudo_params, ask, renewal_price, response)?;
+    response = renew_name(deps, &env, &sudo_params, ask, final_price, response)?;
 
     Ok(response)
 }

--- a/contracts/marketplace/src/execute.rs
+++ b/contracts/marketplace/src/execute.rs
@@ -553,7 +553,7 @@ pub fn execute_renew(
         let payment = may_pay(&info, NATIVE_DENOM)?;
 
         ask.renewal_fund += payment;
-    
+
         ensure!(
             ask.renewal_fund >= renewal_price,
             ContractError::InsufficientRenewalFunds {

--- a/contracts/name-minter/schema/name-minter.json
+++ b/contracts/name-minter/schema/name-minter.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "name-minter",
-  "contract_version": "2.2.0",
+  "contract_version": "2.2.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/sg721-name/schema/sg721-name.json
+++ b/contracts/sg721-name/schema/sg721-name.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "sg721-name",
-  "contract_version": "2.2.0",
+  "contract_version": "2.2.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
This change should allow a no-cost manual renewal of a  name _without a valid bid_ to address issues found by @jhernandezb when testing in `beta`.

Note: includes commit to bump patch version