### PR TITLE
Support prefunding _before_ renewal window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "name-marketplace"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "name-minter"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "sg-name"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "sg-name-common"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "sg-name-market"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "sg-name-minter"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "sg-whitelist-basic"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "sg721-name"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1331,7 +1331,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "whitelist-updatable"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "whitelist-updatable-flatrate"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["packages/*", "contracts/*"]
 resolver = "2"
 
 [workspace.package]
-version    = "2.3.0"
+version    = "2.3.1"
 edition    = "2021"
 homepage   = "https://stargaze.zone"
 repository = "https://github.com/public-awesome/names"

--- a/contracts/marketplace/schema/name-marketplace.json
+++ b/contracts/marketplace/schema/name-marketplace.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "name-marketplace",
-  "contract_version": "2.3.0",
+  "contract_version": "2.3.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/marketplace/src/query.rs
+++ b/contracts/marketplace/src/query.rs
@@ -206,9 +206,12 @@ pub fn query_ask_renew_price(
 
     let ask_renew_start_time = ask.renewal_time.seconds() - sudo_params.renew_window;
 
-    if current_time.seconds() < ask_renew_start_time {
-        return Ok((None, None));
-    }
+    // NOTE: disabling to support prefunding before renewal window
+    //       this may be re-enabled if the prefunding logic needs
+    //       to be supported again
+    // if current_time.seconds() < ask_renew_start_time {
+    //     return Ok((None, None));
+    // }
 
     let name_minter = NAME_MINTER.load(deps.storage)?;
     let name_minter_params = deps

--- a/contracts/marketplace/src/query.rs
+++ b/contracts/marketplace/src/query.rs
@@ -204,11 +204,11 @@ pub fn query_ask_renew_price(
     let ask = asks().load(deps.storage, ask_key(&token_id))?;
     let sudo_params = SUDO_PARAMS.load(deps.storage)?;
 
-    let ask_renew_start_time = ask.renewal_time.seconds() - sudo_params.renew_window;
-
     // NOTE: disabling to support prefunding before renewal window
     //       this may be re-enabled if the prefunding logic needs
     //       to be supported again
+    // let ask_renew_start_time = ask.renewal_time.seconds() - sudo_params.renew_window;
+
     // if current_time.seconds() < ask_renew_start_time {
     //     return Ok((None, None));
     // }

--- a/contracts/name-minter/schema/name-minter.json
+++ b/contracts/name-minter/schema/name-minter.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "name-minter",
-  "contract_version": "2.3.0",
+  "contract_version": "2.3.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/name-minter/src/integration_tests.rs
+++ b/contracts/name-minter/src/integration_tests.rs
@@ -1145,9 +1145,9 @@ mod query {
             },
         );
         assert!(result.is_ok());
-
-        let (renewal_price, _renewal_bid) = result.unwrap();
-        assert!(renewal_price.is_none());
+        // NOTE: disabling to support prefunding before renewal window
+        // let (renewal_price, _renewal_bid) = result.unwrap();
+        // assert!(renewal_price.is_none());
 
         update_block_time(&mut app, SECONDS_PER_YEAR - (60 * 60 * 24 * 30));
 

--- a/contracts/sg721-name/schema/sg721-name.json
+++ b/contracts/sg721-name/schema/sg721-name.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "sg721-name",
-  "contract_version": "2.3.0",
+  "contract_version": "2.3.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
These changes allow pre-funding a name renewal _before_ the renewal window opens. It removes the window check (commented out in case it is desired to reenable in the future...this could potentially be converted into a sudoparam and controlled via gov).

NOTE: there are consequences to this action. Take the following scenario:

```
1. name renewal is pre-funded
2. renewal window opens 30-days before the renewal deadline
3. valid_bid is made on the name
4. pre-funding amount is > 5% of valid_bid
5. renewal deadline comes, end blocker runs
6. name is renewed
7. excess pre-funded STARS are not returned to the pre-funder
```

im not sure if this is _good_ or _badddd_...it just _is_ what would happen. the owner can always refund the excess STARS...however it will not be automatic....